### PR TITLE
Add custom decorator for validating users

### DIFF
--- a/bookings/views.py
+++ b/bookings/views.py
@@ -1,13 +1,13 @@
 import calendar
 from datetime import date, datetime, timedelta
 from django.shortcuts import render, redirect, reverse, get_object_or_404
-from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.db.models import Q
 from django.http import HttpResponseRedirect
 from .models import Booking
 from .forms import BookingForm
 from .utils import BookingCalendar
+from main.decorators import validate_user
 
 
 def get_date(d):
@@ -41,13 +41,9 @@ def get_next_month(d):
     return month
 
 
-@login_required()
+@validate_user()
 def bookings(request):
     """ A view to return the admin-only Bookings page """
-    if not request.user.is_superuser:
-        # user is not superuser; take them home
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("home"))
     # generate utils.BookingCalendar using month-args
     d = get_date(request.GET.get("month", None))
     calendar = BookingCalendar(d.year, d.month)
@@ -71,13 +67,9 @@ def bookings(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def add_booking(request):
     """ A view to add a single booking """
-    if not request.user.is_superuser:
-        # user is not superuser; take them home
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("home"))
     booking_form = BookingForm(request.POST or None)
     if request.method == "POST":
         if booking_form.is_valid():
@@ -93,13 +85,9 @@ def add_booking(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_booking(request, id):
     """ A view to update a single booking """
-    if not request.user.is_superuser:
-        # user is not superuser; take them home
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("home"))
     booking = get_object_or_404(Booking, id=id)
     booking_form = BookingForm(request.POST or None, instance=booking)
     if request.method == "POST":
@@ -117,13 +105,9 @@ def update_booking(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_booking(request, id):
     """ A view to delete a specific booking """
-    if not request.user.is_superuser:
-        # user is not superuser; take them home
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("home"))
     booking = get_object_or_404(Booking, id=id)
     booking.delete()
     messages.success(request, "Booking Deleted!")

--- a/destinations/views.py
+++ b/destinations/views.py
@@ -1,11 +1,11 @@
 from django.shortcuts import render, redirect, reverse, get_object_or_404
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from .models import Destination, Sight, Tour
 from .forms import DestinationForm, SightForm, TourForm
 from gallery.models import Photo
+from main.decorators import validate_user
 
 
 MAP_URL = settings.MAP_URL
@@ -25,13 +25,9 @@ def destinations(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def add_destination(request):
     """ A view to add a single destination """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all destinations
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("destinations"))
     destination_form = DestinationForm(request.POST or None)
     if request.method == "POST":
         if destination_form.is_valid():
@@ -64,13 +60,9 @@ def view_destination(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_destination(request, id):
     """ A view to update a specific destination """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all destinations
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("destinations"))
     destination = get_object_or_404(Destination, id=id)
     destination_form = DestinationForm(request.POST or None, instance=destination)
     if request.method == "POST":
@@ -90,26 +82,18 @@ def update_destination(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_destination(request, id):
     """ A view to delete a single destination """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all destinations
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("destinations"))
     destination = get_object_or_404(Destination, id=id)
     messages.success(request, f"{destination.name} Deleted!")
     destination.delete()
     return redirect(reverse("destinations"))
 
 
-@login_required
+@validate_user()
 def add_sight(request, id):
     """ A view to add a single sight/POI """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all destinations
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("destinations"))
     destination = get_object_or_404(Destination, id=id)
     sight_form = SightForm(request.POST or None, initial={"destination": id})
     if request.method == "POST":
@@ -146,13 +130,9 @@ def view_sight(request, d_id, s_id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_sight(request, d_id, s_id):
     """ A view to update a specific sight """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all destinations
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("destinations"))
     destination = get_object_or_404(Destination, id=d_id)
     sight = get_object_or_404(Sight, id=s_id)
     sight_form = SightForm(request.POST or None, instance=sight)
@@ -174,26 +154,18 @@ def update_sight(request, d_id, s_id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_sight(request, d_id, s_id):
     """ A view to delete a single sight """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all destinations
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("destinations"))
     sight = get_object_or_404(Sight, id=s_id)
     messages.success(request, f"{sight.name} Deleted!")
     sight.delete()
     return redirect(reverse("destinations"))
 
 
-@login_required
+@validate_user()
 def add_tour(request):
     """ A view to add a single tour """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to the home page
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("home"))
     tour_form = TourForm(request.POST or None)
     if request.method == "POST":
         if tour_form.is_valid():
@@ -208,13 +180,9 @@ def add_tour(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_tour(request, id):
     """ A view to update a specific tour """
-    if not request.user.is_superuser:
-        # user is not superuser; take them home
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("home"))
     tour = get_object_or_404(Tour, id=id)
     tour_form = TourForm(request.POST or None, instance=tour)
     if request.method == "POST":
@@ -232,13 +200,9 @@ def update_tour(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_tour(request, id):
     """ A view to delete a single tour """
-    if not request.user.is_superuser:
-        # user is not superuser; take them home
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("home"))
     tour = get_object_or_404(Tour, id=id)
     messages.success(request, f"{tour.category} Deleted!")
     tour.delete()

--- a/faqs/views.py
+++ b/faqs/views.py
@@ -1,8 +1,8 @@
 from django.shortcuts import render, redirect, reverse, get_object_or_404
-from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from .models import FAQ
 from .forms import FAQForm
+from main.decorators import validate_user
 
 
 def faqs(request):
@@ -18,13 +18,9 @@ def faqs(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def add_faq(request):
     """ A view to add a new FAQ """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to FAQs
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("faqs"))
     faq_form = FAQForm(request.POST or None)
     if request.method == "POST":
         if faq_form.is_valid:
@@ -38,13 +34,9 @@ def add_faq(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_faq(request, id):
     """ A view to update a specific FAQ """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to FAQs
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("faqs"))
     faq = get_object_or_404(FAQ, id=id)
     faq_form = FAQForm(request.POST or None, instance=faq)
     if request.method == "POST":
@@ -60,13 +52,9 @@ def update_faq(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_faq(request, id):
     """ A view to delete a specific FAQ """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to FAQs
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("faqs"))
     faq = get_object_or_404(FAQ, id=id)
     faq.delete()
     messages.success(request, "FAQ Deleted!")

--- a/gallery/views.py
+++ b/gallery/views.py
@@ -1,9 +1,9 @@
 from django.shortcuts import render, redirect, reverse, get_object_or_404
-from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from .models import Photo
 from .forms import PhotoForm
+from main.decorators import validate_user
 
 
 def gallery(request):
@@ -19,13 +19,9 @@ def gallery(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def add_photo(request):
     """ A view to add a single photo """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to the gallery
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("gallery"))
     photo_form = PhotoForm(request.POST or None, request.FILES or None)
     if request.method == "POST":
         if photo_form.is_valid():
@@ -41,13 +37,9 @@ def add_photo(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_photo(request, id):
     """ A view to update a single photo """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to the gallery
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("gallery"))
     photo = get_object_or_404(Photo, id=id)
     photo_form = PhotoForm(request.POST or None, request.FILES or None, instance=photo)
     if request.method == "POST":
@@ -65,13 +57,9 @@ def update_photo(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_photo(request, id):
     """ A view to delete a specific photo """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to the gallery
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("gallery"))
     photo = get_object_or_404(Photo, id=id)
     photo.delete()
     messages.success(request, "Photo Deleted!")

--- a/main/decorators.py
+++ b/main/decorators.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from django.contrib import messages
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import reverse, redirect
+
+
+def validate_user(redirect_url="home", redirect_kwargs={}):
+    def decorator(view_function):
+        @wraps(view_function)
+        def wrapped_view(request, *args, **kwargs):
+            authorized = request.user.is_superuser
+
+            if not authorized and redirect_url:
+                messages.error(request, "Access denied. Invalid permissions.")
+                return redirect(reverse(redirect_url, kwargs=redirect_kwargs))
+            elif not authorized:
+                raise PermissionDenied("Access denied. Invalid permissions.")
+
+            return view_function(request, *args, **kwargs)
+
+        return wrapped_view
+
+    return decorator

--- a/resources/views.py
+++ b/resources/views.py
@@ -1,10 +1,10 @@
 from django.shortcuts import render, redirect, reverse, get_object_or_404
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from .models import Phrase
 from .forms import PhraseForm
+from main.decorators import validate_user
 
 
 def resources(request):
@@ -34,13 +34,9 @@ def phrases(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def add_phrase(request):
     """ A view to add a single phrase """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all phrases
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("phrases"))
     phrase_form = PhraseForm(request.POST or None)
     if request.method == "POST":
         if phrase_form.is_valid():
@@ -56,13 +52,9 @@ def add_phrase(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_phrase(request, id):
     """ A view to update a single phrase """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all phrases
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("phrases"))
     phrase = get_object_or_404(Phrase, id=id)
     phrase_form = PhraseForm(request.POST or None, instance=phrase)
     if request.method == "POST":
@@ -80,13 +72,9 @@ def update_phrase(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_phrase(request, id):
     """ A view to delete a specific phrase """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all phrases
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("phrases"))
     phrase = get_object_or_404(Phrase, id=id)
     phrase.delete()
     messages.success(request, "Phrase Deleted!")

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -1,9 +1,9 @@
 from django.shortcuts import render, redirect, reverse, get_object_or_404
-from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from .models import Review
 from .forms import ReviewForm
+from main.decorators import validate_user
 
 
 
@@ -20,13 +20,9 @@ def reviews(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def add_review(request):
     """ A view to add a single review """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all reviews
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("reviews"))
     review_form = ReviewForm(request.POST or None, request.FILES or None)
     if request.method == "POST":
         if review_form.is_valid():
@@ -42,13 +38,9 @@ def add_review(request):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def update_review(request, id):
     """ A view to update a single review """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all reviews
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("reviews"))
     review = get_object_or_404(Review, id=id)
     review_form = ReviewForm(request.POST or None, request.FILES or None, instance=review)
     if request.method == "POST":
@@ -66,13 +58,9 @@ def update_review(request, id):
     return render(request, template, context)
 
 
-@login_required
+@validate_user()
 def delete_review(request, id):
     """ A view to delete a specific review """
-    if not request.user.is_superuser:
-        # user is not superuser; take them to all reviews
-        messages.error(request, "Access denied. Invalid permissions.")
-        return redirect(reverse("reviews"))
     review = get_object_or_404(Review, id=id)
     review.delete()
     messages.success(request, "Review Deleted!")


### PR DESCRIPTION
Fixes #42.

Added custom decorator to avoid using `@login_required`, which redirects users to the login page.
Instead, new custom decorator `@validate_user` will check the same thing, but now appropriately displays the `messages.error()` message and redirects anonymous users back to the **home** page.