### PR TITLE
Fix label-for attributes on destination CRUD pages

### DIFF
--- a/destinations/templates/destinations/add_destination.html
+++ b/destinations/templates/destinations/add_destination.html
@@ -37,7 +37,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-flag fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ destination_form.province }}
-                                <label for="id_name">* Province</label>
+                                <label for="id_province">* Province</label>
                             </div>
 						</div>
 
@@ -46,7 +46,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-atlas fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ destination_form.description }}
-                                <label for="id_name">* Description</label>
+                                <label for="id_description">* Description</label>
                             </div>
 						</div>
 

--- a/destinations/templates/destinations/add_sight.html
+++ b/destinations/templates/destinations/add_sight.html
@@ -38,7 +38,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-map-marked-alt fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ sight_form.category }}
-                                <label for="id_name">* Category</label>
+                                <label for="id_category">* Category</label>
                             </div>
 						</div>
 
@@ -47,7 +47,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-atlas fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ sight_form.description }}
-                                <label for="id_name">* Description</label>
+                                <label for="id_description">* Description</label>
                             </div>
 						</div>
 
@@ -77,7 +77,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-map-marked-alt fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ sight_form.destination }}
-                                <label for="id_name">* Destination</label>
+                                <label for="id_destination">* Destination</label>
                             </div>
 						</div>
 

--- a/destinations/templates/destinations/add_tour.html
+++ b/destinations/templates/destinations/add_tour.html
@@ -27,7 +27,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-compass fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ tour_form.category }}
-                                <label for="id_name">* Tour Category</label>
+                                <label for="id_category">* Tour Category</label>
                             </div>
 						</div>
 
@@ -35,7 +35,7 @@
 						<div class="input-group mb-3">
                             <div class="form-floating flex-grow-1">
                                 {{ tour_form.photo }}
-                                <label for="id_name">* Photo</label>
+                                <label for="id_photo">* Photo</label>
                             </div>
 						</div>
 
@@ -44,7 +44,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-atlas fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ tour_form.description }}
-                                <label for="id_name">* Description</label>
+                                <label for="id_description">* Description</label>
                             </div>
 						</div>
 

--- a/destinations/templates/destinations/update_destination.html
+++ b/destinations/templates/destinations/update_destination.html
@@ -38,7 +38,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-flag fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ destination_form.province }}
-                                <label for="id_name">* Province</label>
+                                <label for="id_province">* Province</label>
                             </div>
 						</div>
 
@@ -47,7 +47,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-atlas fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ destination_form.description }}
-                                <label for="id_name">* Description</label>
+                                <label for="id_description">* Description</label>
                             </div>
 						</div>
 

--- a/destinations/templates/destinations/update_sight.html
+++ b/destinations/templates/destinations/update_sight.html
@@ -39,7 +39,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-map-marked-alt fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ sight_form.category }}
-                                <label for="id_name">* Category</label>
+                                <label for="id_category">* Category</label>
                             </div>
 						</div>
 
@@ -48,7 +48,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-atlas fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ sight_form.description }}
-                                <label for="id_name">* Description</label>
+                                <label for="id_description">* Description</label>
                             </div>
 						</div>
 
@@ -78,7 +78,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-map-marked-alt fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ sight_form.destination }}
-                                <label for="id_name">* Destination</label>
+                                <label for="id_destination">* Destination</label>
                             </div>
 						</div>
 

--- a/destinations/templates/destinations/update_tour.html
+++ b/destinations/templates/destinations/update_tour.html
@@ -27,7 +27,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-compass fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ tour_form.category }}
-                                <label for="id_name">* Tour Category</label>
+                                <label for="id_category">* Tour Category</label>
                             </div>
 						</div>
 
@@ -35,7 +35,7 @@
 						<div class="input-group mb-3">
                             <div class="form-floating flex-grow-1">
                                 {{ tour_form.photo }}
-                                <label for="id_name">* Photo</label>
+                                <label for="id_photo">* Photo</label>
                             </div>
 						</div>
 
@@ -44,7 +44,7 @@
                             <span class="input-group-text bg-secondary bg-opacity-25 text-dark d-none d-md-flex"><i class="fas fa-atlas fa-fw"></i></span>
                             <div class="form-floating flex-grow-1">
                                 {{ tour_form.description }}
-                                <label for="id_name">* Description</label>
+                                <label for="id_description">* Description</label>
                             </div>
 						</div>
 


### PR DESCRIPTION
Fix `<label for="">` attributes on the Destinations App for CRUD pages.
A copy/paste job from yesterday meant all fields used `<label for="id_name">` instead of their respective fields.