### PR TITLE
Fix Issue #94 related to quickbars for TinyMCE

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -150,8 +150,11 @@ MAP_URL = os.environ.get("MAP_URL")
 
 # TinyMCE WYSIWYG - https://www.tiny.cloud/docs/plugins/opensource
 TINYMCE_DEFAULT_CONFIG = {
-    "plugins": "quickbars lists advlist autolink link preview searchreplace table paste help wordcount",
+    "plugins": "quickbars lists advlist autolink link preview searchreplace table paste wordcount",
     "toolbar": "undo redo | styleselect forecolor backcolor | copy paste | bold italic underline removeformat | numlist bullist | link",
+    "quickbars_insert_toolbar": "false",
+    "quickbars_image_toolbar": "false",
+    "quickbars_selection_toolbar": "bold italic underline | forecolor backcolor | quicklink blockquote",
 }
 
 # Crispy Forms (Bootstrap 5)


### PR DESCRIPTION
Issue #94 fixed.
Removed "help" option, and customized "quickbars" so images cannot be uploaded to the textfields through TinyMCE.