### PR TITLE
Add cookies banner using localStorage; Issue #124

### DIFF
--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -311,6 +311,9 @@
     <!-- footer -->
     {% include "partials/footer.html" %}
 
+    <!-- banner for cookies -->
+    {% include "partials/banner_cookies.html" %}
+
     <!-- scripts -->
     {% include "partials/scripts.html" %}
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -302,6 +302,10 @@ aside#overlay.hide {
     opacity: 1;
 }
 
+#banner-cookies {
+    z-index: 999;
+}
+
 /* NAVBAR */
 header#navbar-header {
     position: sticky;
@@ -1277,6 +1281,11 @@ footer .fas:hover {
 
 .footer-social-img {
     width: 3em;
+    transition: all 0.3s ease-in-out;
+}
+
+.footer-social-img:hover {
+    filter: grayscale(1);
 }
 
 /* BOOTSTRAP: SMALL */

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,4 +1,6 @@
-/* jshint esversion: 11, jquery: true */
+/* ----- jshint esversion: 11, jquery: true ----- */
+
+/* ----- PRELOADER ----- */
 
 // remove preloader animation once page is fully loaded
 $(document).ready(function() {
@@ -9,6 +11,9 @@ $(document).ready(function() {
 //     $("body").removeClass("page-load-complete");
 // });
 
+
+/* ----- TO TOP BUTTON ----- */
+
 // scroll to top button
 let btnTop = document.getElementById("btn-top");
 window.addEventListener("load", viewportMagic, true);
@@ -16,11 +21,14 @@ window.addEventListener("resize", viewportMagic, true);
 window.addEventListener("scroll", viewportMagic, true);
 function viewportMagic() {
     if (window.scrollY > 750) {
-        btnTop.style.cssText = "bottom: 0.5em;";
+        btnTop.style.cssText = "bottom: 0.25em;";
     } else {
         btnTop.style.cssText = "bottom: -3em;";
     }
 }
+
+
+/* ----- NAVBAR LINKS ----- */
 
 // update nav-links with 'active' state
 let activeLink;
@@ -47,8 +55,13 @@ if (location.pathname.includes("/about/")) {
 $(`[id^="nav-link-${activeLink}"]`).removeClass("list-group-item-dark").addClass("active list-group-item-light").prop("aria-current", true);
 
 
+/* ----- COPYRIGHT ----- */
+
 // update copyright year
 document.getElementById("year").innerText = new Date().getFullYear();
+
+
+/* ----- KURDISH TIME ----- */
 
 // get local time in Kurdistan/Iraq
 function updateTime() {
@@ -69,6 +82,9 @@ $("#offcanvas-toggle-btn").on("click", function() {
     $("#nav-link-time").html(updateTime());
 });
 
+
+/* ----- REVIEW BANNER ----- */
+
 // localStorage: remember if user closed the "review banner"
 const btnCloseReview = document.getElementById("btn-close-review");
 const reviewBanner = document.getElementById("banner-review");
@@ -87,6 +103,39 @@ if (!JSON.parse(localStorage.getItem("reviewClosed"))) {
 function closeReviewBanner() {
     localStorage.setItem("reviewClosed", JSON.stringify({"reviewClosed": true}));
 }
+
+
+/* ----- COOKIES ----- */
+
+// localStorage: remember if user closed the "cookies banner"
+const btnCloseCookies = document.getElementById("btn-close-cookies");
+const cookiesBanner = document.getElementById("banner-cookies");
+
+// adjust padding-bottom on body to accommodate fixed-banner size
+$(window).on("load resize", function() {
+    let cookiesBannerHeight = $(cookiesBanner).height();
+    document.body.style.paddingBottom = `${cookiesBannerHeight}px`;
+
+    // check for existing localStorage of "cookies banner" being closed previously
+    if (!JSON.parse(localStorage.getItem("cookiesClosed"))) {
+        // none found / allow clicking to close banner
+        btnCloseCookies?.addEventListener("click", closeCookiesBanner);
+    } else {
+        // previously closed / auto-hide banner from now on
+        cookiesBanner.classList.remove("show");
+        cookiesBanner.classList.add("d-none");
+        document.body.style.paddingBottom = "unset";
+    }
+});
+
+// add localStorage for "cookies banner" being closed
+function closeCookiesBanner() {
+    localStorage.setItem("cookiesClosed", JSON.stringify({"cookiesClosed": true}));
+    document.body.style.paddingBottom = "unset";
+}
+
+
+/* ----- ALERTS ----- */
 
 // auto-hide alerts
 const alerts = document.querySelectorAll("aside.alert");
@@ -113,6 +162,9 @@ if (alerts.length > 0) {
     }
 }
 
+
+/* ----- BREADCRUMBS  ----- */
+
 // auto-expand/collapse breadcrumb dropdown-menu on hover
 let breadcrumbDropdown = document.querySelectorAll(".breadcrumb-item.dropdown");
 breadcrumbDropdown.forEach(dropdown => {
@@ -136,14 +188,17 @@ breadcrumbDropdown.forEach(dropdown => {
     });
 });
 
-/*
-    Initialize Bootstrap Components
-*/
+
+/* ----- BOOTSTRAP COMPONENTS ----- */
+
 // tooltips
 let tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
 let tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
     return new bootstrap.Tooltip(tooltipTriggerEl);
 });
+
+
+/* ----- WISHLIST (destinations) ----- */
 
 // handling localStorage for "destinations"
 $("body").on("click", ".destination-card-text", function(e) {
@@ -225,7 +280,10 @@ function removeWishlistDestination(e, destination) {
     
 }
 
-// CRUD functionality: disable first <option> in each <select> input (exception: booking guide defaults to Haval)
+
+/* ----- CRUD Functionality ----- */
+
+// disable first <option> in each <select> input (exception: booking guide defaults to Haval)
 $("select:not(#id_guide)").each(function() {
     $(this).children("option:first").prop("disabled", true);
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,6 +47,9 @@
     <!-- footer -->
     {% include "partials/footer.html" %}
 
+    <!-- banner for coookie -->
+    {% include "partials/banner_cookies.html" %}
+
     <!-- scripts -->
     {% include "partials/scripts.html" %}
 

--- a/templates/partials/banner_cookies.html
+++ b/templates/partials/banner_cookies.html
@@ -1,0 +1,13 @@
+<aside id="banner-cookies" class="toast show position-fixed bottom-0 end-0 fs-6 align-items-center bg-warning border-0 rounded-0 w-100" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+        <div class="toast-body w-100 text-center">
+            <i class="fas fa-cookie-bite"></i>
+            We use only local cookies to ensure you get the best experience.
+            <a href="{% url 'privacy_policy' %}#cookies" class="text-dark">
+                <br class="d-block d-md-none">
+                Learn More
+            </a>
+        </div>
+        <button type="button" class="btn-close btn-close-black me-2 m-auto" data-bs-dismiss="toast" aria-label="Close" id="btn-close-cookies"></button>
+    </div>
+</aside>

--- a/templates/partials/banner_review.html
+++ b/templates/partials/banner_review.html
@@ -1,4 +1,4 @@
-<div id="banner-review" class="toast show fs-5 align-items-center bg-warning border-0 rounded-0 w-100" role="alert" aria-live="assertive" aria-atomic="true">
+<aside id="banner-review" class="toast show fs-5 align-items-center bg-warning border-0 rounded-0 w-100" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="d-flex">
         <div class="toast-body w-100 text-center">
             <a href="https://www.tripadvisor.com/UserReviewEdit-g659505-d14863085-Iraqi_Kurdistan_Guide-Erbil_Erbil_Province.html" target="_blank" rel="noopener" class="text-dark">
@@ -7,4 +7,4 @@
         </div>
         <button type="button" class="btn-close btn-close-black me-2 m-auto" data-bs-dismiss="toast" aria-label="Close" id="btn-close-review"></button>
     </div>
-</div>
+</aside>


### PR DESCRIPTION
Adds new feature from Issue #124 .
Cookie Banner, with localStorage incorporated to remember closed banners.
Dynamically adds `padding-bottom` to the `<body>` element as well, depending on height of the banner for various sizes